### PR TITLE
Make the Firestore api coroutines friendly.

### DIFF
--- a/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Await.kt
+++ b/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Await.kt
@@ -1,0 +1,54 @@
+package io.github.rubenquadros.vibesync.firestore
+
+import com.google.cloud.firestore.DocumentReference
+import com.google.cloud.firestore.ListenerRegistration
+import com.google.cloud.firestore.Query
+import com.google.cloud.firestore.QueryDocumentSnapshot
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal suspend fun Query.await(): List<QueryDocumentSnapshot> {
+
+    var listener: ListenerRegistration? = null
+
+    fun cleanup() {
+        listener?.remove()
+        listener = null
+    }
+
+    val result = suspendCancellableCoroutine { cancellableContinuation ->
+        listener = this.addSnapshotListener { value, error ->
+            cleanup()
+            if (error != null) {
+                cancellableContinuation.resumeWithException(error)
+            } else {
+                cancellableContinuation.resume(value!!.documents)
+            }
+        }
+    }
+
+    return result
+}
+
+internal suspend fun DocumentReference.await(): Map<String, Any>? {
+    var listener: ListenerRegistration? = null
+
+    fun cleanup() {
+        listener?.remove()
+        listener = null
+    }
+
+    val result = suspendCancellableCoroutine { cancellableContinuation ->
+        listener = this.addSnapshotListener { value, error ->
+            cleanup()
+            if (error != null) {
+                cancellableContinuation.resumeWithException(error)
+            } else {
+                cancellableContinuation.resume(value!!.data)
+            }
+        }
+    }
+
+    return result
+}

--- a/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Extensions.kt
+++ b/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Extensions.kt
@@ -9,17 +9,6 @@ internal fun DocumentSnapshot.getDataMap(): Map<String, Any> {
 }
 
 @Suppress("UNCHECKED_CAST")
-internal fun DocumentSnapshot.getImages(): List<Image> {
-    return (this["images"] as List<Map<*, *>>).map {
-        Image(
-            width = (it["width"] as Long).toInt(),
-            height = (it["height"] as Long).toInt(),
-            url = it["url"] as? String
-        )
-    }
-}
-
-@Suppress("UNCHECKED_CAST")
 internal fun Map<String, Any>.getImages(): List<Image> {
     return (this["images"] as List<Map<*, *>>).map {
         Image(

--- a/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/FirestoreApiImpl.kt
+++ b/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/FirestoreApiImpl.kt
@@ -47,14 +47,14 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getTopArtists(): FirestoreApiResponse<List<TopEntity>> {
         return getFirestoreResponse {
-            val future = firestore.collection("top_artists").get()
-            val topArtists = future.get().documents.map { queryDocumentSnapshot: QueryDocumentSnapshot ->
-                TopEntity(
-                    id = queryDocumentSnapshot["id"].toString(),
-                    name = queryDocumentSnapshot["name"].toString(),
-                    image = queryDocumentSnapshot["image"].toString()
-                )
-            }
+            val topArtists =
+                firestore.collection("top_artists").await().map { queryDocumentSnapshot: QueryDocumentSnapshot ->
+                    TopEntity(
+                        id = queryDocumentSnapshot["id"].toString(),
+                        name = queryDocumentSnapshot["name"].toString(),
+                        image = queryDocumentSnapshot["image"].toString()
+                    )
+                }
 
             getSuccessResponse(topArtists)
         }
@@ -62,14 +62,14 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getTopTracks(): FirestoreApiResponse<List<TopEntity>> {
         return getFirestoreResponse {
-            val future = firestore.collection("top_tracks").get()
-            val topTracks = future.get().documents.map { queryDocumentSnapshot: QueryDocumentSnapshot ->
-                TopEntity(
-                    id = queryDocumentSnapshot["id"].toString(),
-                    name = queryDocumentSnapshot["name"].toString(),
-                    image = queryDocumentSnapshot["image"].toString()
-                )
-            }
+            val topTracks =
+                firestore.collection("top_tracks").await().map { queryDocumentSnapshot: QueryDocumentSnapshot ->
+                    TopEntity(
+                        id = queryDocumentSnapshot["id"].toString(),
+                        name = queryDocumentSnapshot["name"].toString(),
+                        image = queryDocumentSnapshot["image"].toString()
+                    )
+                }
 
             getSuccessResponse(topTracks)
         }
@@ -77,14 +77,14 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getTopAlbums(): FirestoreApiResponse<List<TopEntity>> {
         return getFirestoreResponse {
-            val future = firestore.collection("top_albums").get()
-            val topAlbums = future.get().documents.map { queryDocumentSnapshot: QueryDocumentSnapshot ->
-                TopEntity(
-                    id = queryDocumentSnapshot["id"].toString(),
-                    name = queryDocumentSnapshot["name"].toString(),
-                    image = queryDocumentSnapshot["image"].toString()
-                )
-            }
+            val topAlbums =
+                firestore.collection("top_albums").await().map { queryDocumentSnapshot: QueryDocumentSnapshot ->
+                    TopEntity(
+                        id = queryDocumentSnapshot["id"].toString(),
+                        name = queryDocumentSnapshot["name"].toString(),
+                        image = queryDocumentSnapshot["image"].toString()
+                    )
+                }
 
             getSuccessResponse(topAlbums)
         }
@@ -92,14 +92,14 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getRecentTracks(): FirestoreApiResponse<List<TopEntity>> {
         return getFirestoreResponse {
-            val future = firestore.collection("recent_tracks").get()
-            val recentTracks = future.get().documents.map { queryDocumentSnapshot: QueryDocumentSnapshot ->
-                TopEntity(
-                    id = queryDocumentSnapshot["id"].toString(),
-                    name = queryDocumentSnapshot["name"].toString(),
-                    image = queryDocumentSnapshot["image"].toString()
-                )
-            }
+            val recentTracks =
+                firestore.collection("recent_tracks").await().map { queryDocumentSnapshot: QueryDocumentSnapshot ->
+                    TopEntity(
+                        id = queryDocumentSnapshot["id"].toString(),
+                        name = queryDocumentSnapshot["name"].toString(),
+                        image = queryDocumentSnapshot["image"].toString()
+                    )
+                }
 
             getSuccessResponse(recentTracks)
         }
@@ -107,8 +107,7 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getUserProfile(id: String): FirestoreApiResponse<UserProfile> {
         return getFirestoreResponse {
-            val future = firestore.collection("users").document(id).get()
-            future.get().data?.let {
+            firestore.collection("users").document(id).await()?.let {
                 getSuccessResponse(
                     UserProfile(
                         id = it["id"].toString(),
@@ -191,10 +190,10 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getLikedTracks(userId: String): FirestoreApiResponse<List<TrackInfo>> {
         return getFirestoreResponse {
-            val future = firestore.collection("users").document(userId).collection("liked_tracks")
-                .orderBy("timestamp", Query.Direction.DESCENDING).limit(10).get()
+            val query = firestore.collection("users").document(userId).collection("liked_tracks")
+                .orderBy("timestamp", Query.Direction.DESCENDING).limit(10)
 
-            val likedTracks = future.get().documents.map { queryDocumentSnapshot: QueryDocumentSnapshot ->
+            val likedTracks = query.await().map { queryDocumentSnapshot: QueryDocumentSnapshot ->
                 val data = queryDocumentSnapshot.getDataMap()
                 TrackInfo(
                     id = data["id"].toString(),
@@ -240,10 +239,10 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getLikedAlbums(userId: String): FirestoreApiResponse<List<MediaInfo>> {
         return getFirestoreResponse {
-            val future = firestore.collection("users").document(userId).collection("liked_albums")
-                .orderBy("timestamp", Query.Direction.DESCENDING).limit(10).get()
+            val query = firestore.collection("users").document(userId).collection("liked_albums")
+                .orderBy("timestamp", Query.Direction.DESCENDING).limit(10)
 
-            val likedAlbums = future.get().documents.map { queryDocumentSnapshot: QueryDocumentSnapshot ->
+            val likedAlbums = query.await().map { queryDocumentSnapshot: QueryDocumentSnapshot ->
                 val data = queryDocumentSnapshot.getDataMap()
                 MediaInfo(
                     id = data["id"].toString(),
@@ -313,10 +312,10 @@ class FirestoreApiImpl : FirestoreApi {
 
     override suspend fun getUserPlaylists(userId: String): FirestoreApiResponse<List<PlaylistInfo>> {
         return getFirestoreResponse {
-            val future = firestore.collection("users").document(userId).collection("playlists")
-                .orderBy("updatedAt", Query.Direction.DESCENDING).limit(10).get()
+            val query = firestore.collection("users").document(userId).collection("playlists")
+                .orderBy("updatedAt", Query.Direction.DESCENDING).limit(10)
 
-            val playlists = future.get().documents.map { queryDocumentSnapshot: QueryDocumentSnapshot ->
+            val playlists = query.await().map { queryDocumentSnapshot: QueryDocumentSnapshot ->
                 val data = queryDocumentSnapshot.getDataMap()
                 PlaylistInfo(
                     id = data["id"].toString(),
@@ -407,7 +406,11 @@ class FirestoreApiImpl : FirestoreApi {
         }
     }
 
-    override suspend fun getPlaylistTracks(userId: String, playlistId: String, offset: Int): FirestoreApiResponse<TracksPaginatedResponse> {
+    override suspend fun getPlaylistTracks(
+        userId: String,
+        playlistId: String,
+        offset: Int
+    ): FirestoreApiResponse<TracksPaginatedResponse> {
         return getFirestoreResponse {
             val query = firestore.collection("playlists").document(playlistId).collection("tracks")
 

--- a/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Helper.kt
+++ b/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Helper.kt
@@ -7,7 +7,7 @@ import io.github.rubenquadros.vibesync.firestore.model.getErrorResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-internal suspend fun <R>getFirestoreResponse(block: () -> FirestoreApiResponse<R>): FirestoreApiResponse<R> {
+internal suspend fun <R>getFirestoreResponse(block: suspend () -> FirestoreApiResponse<R>): FirestoreApiResponse<R> {
     return runCatching {
         withContext(Dispatchers.IO) {
             block()

--- a/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Pager.kt
+++ b/firestore/src/main/kotlin/io/github/rubenquadros/vibesync/firestore/Pager.kt
@@ -10,7 +10,7 @@ class Pager {
         private const val PAGE_SIZE = 20
     }
 
-    fun getPage(offset: Int, query: Query): PageResponse {
+    suspend fun getPage(offset: Int, query: Query): PageResponse {
         var lastDocument: DocumentSnapshot? = null
         val totalDocumentsToSkip = offset * PAGE_SIZE
 
@@ -24,9 +24,9 @@ class Pager {
                     query.limit(PAGE_SIZE)
                 }
 
-                val snapshot = q.get().get()
-                if (snapshot.documents.isEmpty()) return PageResponse()
-                lastDocument = snapshot.documents.lastOrNull()
+                val queryDocumentSnapshot = q.await()
+                if (queryDocumentSnapshot.isEmpty()) return PageResponse()
+                lastDocument = queryDocumentSnapshot.lastOrNull()
             }
         }
 
@@ -36,10 +36,10 @@ class Pager {
             query.limit(PAGE_SIZE + 1)
         }
 
-        val querySnapshot = finalQuery.get().get()
+        val querySnapshot = finalQuery.await()
         return PageResponse(
-            isNext = querySnapshot.size() > PAGE_SIZE,
-            page = querySnapshot.documents.take(PAGE_SIZE)
+            isNext = querySnapshot.size > PAGE_SIZE,
+            page = querySnapshot.take(PAGE_SIZE)
         )
     }
 


### PR DESCRIPTION
Instead of depending on ApiFuture, we now depend on listeners. 
This will at least not block the thread.